### PR TITLE
arm64: dts: mediatek: xaga: bring up USB peripheral and guarded OTG host support

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt6895-xaga-usb-tcpm.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt6895-xaga-usb-tcpm.dtsi
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/* Local OTG candidate: TCPM owns VBUS; MTU3 owns only the USB data role. */
+&ssusb {
+	/delete-property/ vbus-supply;
+};
+
+&{/soc@0/i2c@11280000/mt6375@34/tcpc} {
+	vbus-supply = <&otg_vbus>;
+	power-supplies = <&xaga_managed_charger>;
+};
+
+&{/soc@0/i2c@11280000/mt6375@34/tcpc/connector} {
+	power-role = "dual";
+	data-role = "dual";
+	try-power-role = "sink";
+	source-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_DUAL_ROLE |
+				PDO_FIXED_DATA_SWAP | PDO_FIXED_USB_COMM)>;
+	sink-pdos = <PDO_FIXED(5000, 1500, PDO_FIXED_DUAL_ROLE |
+			      PDO_FIXED_DATA_SWAP | PDO_FIXED_USB_COMM)>;
+	op-sink-microwatt = <2500000>;
+};
+
+xaga_managed_charger: &{/soc@0/i2c@11280000/mt6375@34/chg} {
+	mediatek,tcpm-managed;
+	aicr = <100>;
+};
+
+&otg_vbus {
+	regulator-min-microvolt = <5000000>;
+	regulator-max-microvolt = <5000000>;
+	regulator-min-microamp = <500000>;
+	regulator-max-microamp = <500000>;
+};

--- a/arch/arm64/boot/dts/mediatek/mt6895-xiaomi-xaga.dts
+++ b/arch/arm64/boot/dts/mediatek/mt6895-xiaomi-xaga.dts
@@ -561,7 +561,7 @@
 	dr_mode = "otg";
 	maximum-speed = "high-speed";
 	usb-role-switch;
-	role-switch-default-mode = "device";
+	role-switch-default-mode = "peripheral";
 	vusb33-supply = <&vusb33>;
 	vbus-supply = <&otg_vbus>;
 
@@ -574,7 +574,7 @@
 
 &usb_host {
 	status = "okay";
-	role-switch-default-mode = "device";
+	role-switch-default-mode = "peripheral";
 	vusb33-supply = <&vusb33>;
 };
 
@@ -1076,3 +1076,6 @@ bias-disable;
 };
 };
 };
+
+/* Local USB/OTG bring-up; TCPM owns power direction and current limits. */
+#include "mt6895-xaga-usb-tcpm.dtsi"

--- a/drivers/i2c/busses/i2c-mt65xx.c
+++ b/drivers/i2c/busses/i2c-mt65xx.c
@@ -1491,12 +1491,22 @@ static int mtk_i2c_probe(struct platform_device *pdev)
 	i2c->adap.quirks = i2c->dev_comp->quirks;
 	i2c->adap.timeout = 2 * HZ;
 	i2c->adap.retries = 1;
-	i2c->adap.bus_regulator = devm_regulator_get_optional(&pdev->dev, "vbus");
-	if (IS_ERR(i2c->adap.bus_regulator)) {
-		if (PTR_ERR(i2c->adap.bus_regulator) == -ENODEV)
-			i2c->adap.bus_regulator = NULL;
-		else
-			return PTR_ERR(i2c->adap.bus_regulator);
+	/*
+	 * Only the controller's supply powers SCL/SDA. Regulator lookup also
+	 * searches child nodes, where vbus-supply may instead describe a USB
+	 * port. Taking that supply can defer this adapter forever when its
+	 * provider is an I2C client on the same bus.
+	 */
+	if (of_property_present(pdev->dev.of_node, "vbus-supply")) {
+		i2c->adap.bus_regulator = devm_regulator_get_optional(&pdev->dev, "vbus");
+		if (IS_ERR(i2c->adap.bus_regulator)) {
+			if (PTR_ERR(i2c->adap.bus_regulator) == -ENODEV)
+				i2c->adap.bus_regulator = NULL;
+			else
+				return dev_err_probe(&pdev->dev,
+					PTR_ERR(i2c->adap.bus_regulator),
+					"Failed to get SCL/SDA supply\n");
+		}
 	}
 
 	ret = mtk_i2c_parse_dt(pdev->dev.of_node, i2c);

--- a/drivers/phy/mediatek/phy-mtk-tphy.c
+++ b/drivers/phy/mediatek/phy-mtk-tphy.c
@@ -16,6 +16,7 @@
 #include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/phy/phy.h>
+#include <linux/phy/phy-mtk-usb.h>
 #include <linux/platform_device.h>
 #include <linux/regmap.h>
 
@@ -1443,9 +1444,38 @@ static int mtk_phy_set_mode(struct phy *phy, enum phy_mode mode, int submode)
 {
 	struct mtk_phy_instance *instance = phy_get_drvdata(phy);
 	struct mtk_tphy *tphy = dev_get_drvdata(phy->dev.parent);
+	void __iomem *com = instance->u2_banks.com;
+	int ret;
 
-	if (instance->type == PHY_TYPE_USB2)
-		u2_phy_instance_set_mode(tphy, instance, mode);
+	if (!submode) {
+		if (instance->type == PHY_TYPE_USB2)
+			u2_phy_instance_set_mode(tphy, instance, mode);
+		return 0;
+	}
+
+	if (instance->type != PHY_TYPE_USB2 || mode != PHY_MODE_USB_DEVICE)
+		return -EINVAL;
+
+	if (submode != MTK_PHY_MODE_BC11_SET &&
+	    submode != MTK_PHY_MODE_BC11_CLR)
+		return -EOPNOTSUPP;
+
+	/*
+	 * Charger detection shares DP/DM with USB. These commands only select
+	 * the BC1.1 path; they must not change IDDIG or the USB data role.
+	 * The charger can call us independently of the USB controller, so
+	 * hold the PHY clocks while accessing the switch register.
+	 */
+	ret = clk_bulk_prepare_enable(TPHY_CLKS_CNT, instance->clks);
+	if (ret)
+		return ret;
+
+	if (submode == MTK_PHY_MODE_BC11_SET)
+		mtk_phy_set_bits(com + U3P_USBPHYACR6, PA6_RG_U2_BC11_SW_EN);
+	else
+		mtk_phy_clear_bits(com + U3P_USBPHYACR6, PA6_RG_U2_BC11_SW_EN);
+
+	clk_bulk_disable_unprepare(TPHY_CLKS_CNT, instance->clks);
 
 	return 0;
 }

--- a/drivers/power/supply/mediatek/mt6375-charger.c
+++ b/drivers/power/supply/mediatek/mt6375-charger.c
@@ -15,6 +15,7 @@
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/phy/phy.h>
+#include <linux/phy/phy-mtk-usb.h>
 #include <linux/platform_device.h>
 #include <linux/power_supply.h>
 #include <linux/reboot.h>
@@ -33,8 +34,6 @@ module_param(dbg_log_en, bool, 0644);
 		if (dbg_log_en) \
 			dev_info(dev, "%s " fmt, __func__, ##__VA_ARGS__); \
 	} while (0)
-#define PHY_MODE_BC11_SET 1
-#define PHY_MODE_BC11_CLR 2
 
 /* From the MTK charger stack (mtk_charger.h), kept local for the mainline port. */
 enum mt6375_usbsw {
@@ -254,6 +253,13 @@ struct mt6375_chg_data {
 	struct mutex pe_lock;
 	struct mutex cv_lock;
 	struct mutex hm_lock;
+	/* Serializes negotiated sink power and the OTG regulator callbacks. */
+	struct mutex power_lock;
+	bool tcpm_managed;
+	bool source_enabled;
+	bool power_fault;
+	bool sink_requested;
+	u32 sink_limit_ua;
 	struct workqueue_struct *wq;
 	struct work_struct bc12_work;
 	struct delayed_work detect_hvchg_work;
@@ -520,6 +526,8 @@ static inline int mt6375_chg_field_set(struct mt6375_chg_data *ddata,
 				       enum mt6375_chg_reg_field fd, u32 val);
 static int mt6375_chg_set_usbsw(struct mt6375_chg_data *ddata,
 				enum mt6375_usbsw usbsw);
+static int mt6375_tcpm_source_enable(struct regulator_dev *rdev);
+static int mt6375_tcpm_source_disable(struct regulator_dev *rdev);
 
 static int mt6375_enable_hm(struct mt6375_chg_data *ddata, bool en)
 {
@@ -577,6 +585,9 @@ static int mt6375_set_boost_param(struct mt6375_chg_data *ddata, bool bst)
 	if (ret < 0)
 		return ret;
 	for (i = 0; i < ARRAY_SIZE(regs); i++) {
+		/* TCPM owns discharge timing; never bleed an attached source. */
+		if (ddata->tcpm_managed && regs[i] == MT6375_REG_CHG_VSYS)
+			continue;
 		val = bst ? boost[i] : buck[i];
 		val <<= ffs(msks[i]) - 1;
 		ret = regmap_update_bits(ddata->rmap, regs[i], msks[i], val);
@@ -594,6 +605,8 @@ recover:
 	 * keep the error code from above
 	 */
 	for (; i >= 0; i--) {
+		if (ddata->tcpm_managed && regs[i] == MT6375_REG_CHG_VSYS)
+			continue;
 		val = bst ? buck[i] : boost[i];
 		val <<= ffs(msks[i]) - 1;
 		if (regmap_update_bits(ddata->rmap, regs[i], msks[i],
@@ -759,6 +772,9 @@ static int mt6375_chg_regulator_enable(struct regulator_dev *rdev)
 {
 	int ret;
 	struct mt6375_chg_data *ddata = rdev->reg_data;
+
+	if (ddata->tcpm_managed)
+		return mt6375_tcpm_source_enable(rdev);
 	if (mt6375_chg_is_usb_killer(ddata))
 		return -EIO;
 	ret = mt6375_set_boost_param(ddata, true);
@@ -776,6 +792,9 @@ static int mt6375_chg_regulator_disable(struct regulator_dev *rdev)
 {
 	int ret;
 	struct mt6375_chg_data *ddata = rdev->reg_data;
+
+	if (ddata->tcpm_managed)
+		return mt6375_tcpm_source_disable(rdev);
 
 	ret = mt6375_set_boost_param(ddata, false);
 	if (ret < 0)
@@ -1012,6 +1031,10 @@ static void mt6375_chg_attach_pre_process(struct mt6375_chg_data *ddata,
 {
 	struct mt6375_chg_platform_data *pdata = dev_get_platdata(ddata->dev);
 
+	/* TCPM owns attach and power direction in the managed configuration. */
+	if (ddata->tcpm_managed)
+		return;
+
 	mt_dbg(ddata->dev, "trig=%s,attach=%d\n",
 	       mt6375_attach_trig_names[trig], attach);
 
@@ -1037,6 +1060,9 @@ static void mt6375_chg_pwr_rdy_process(struct mt6375_chg_data *ddata)
 	int ret;
 	u32 val;
 
+	if (ddata->tcpm_managed)
+		return;
+
 	ret = mt6375_chg_field_get(ddata, F_ST_PWR_RDY, &val);
 	if (ret < 0 || ddata->pwr_rdy == val)
 		return;
@@ -1056,6 +1082,9 @@ struct mt6375_chg_data *ddata = container_of(work, struct mt6375_chg_data,
     vbus_check_work.work);
 u32 vbus = 0;
 bool online;
+
+if (ddata->tcpm_managed)
+	return;
 
 if (mt6375_get_vbus(ddata->chgdev, &vbus) == 0)
 online = vbus > 3600000;
@@ -1079,8 +1108,8 @@ static int mt6375_chg_set_usbsw(struct mt6375_chg_data *ddata,
 				enum mt6375_usbsw usbsw)
 {
 	struct phy *phy;
-	int ret, mode = (usbsw == USBSW_CHG) ? PHY_MODE_BC11_SET :
-					       PHY_MODE_BC11_CLR;
+	int ret, mode = (usbsw == USBSW_CHG) ? MTK_PHY_MODE_BC11_SET :
+					       MTK_PHY_MODE_BC11_CLR;
 
 	mt_dbg(ddata->dev, "usbsw=%d\n", usbsw);
 	phy = phy_get(ddata->dev, "usb2-phy");
@@ -1115,6 +1144,13 @@ static int mt6375_chg_enable_bc12(struct mt6375_chg_data *ddata, bool en)
 	static const int max_wait_cnt = 250;
 
 	mt_dbg(ddata->dev, "en=%d\n", en);
+	if (!en) {
+		/* Stop PMIC detection before handing DP/DM back to USB. */
+		ret = mt6375_chg_field_set(ddata, F_BC12_EN, 0);
+		if (ret)
+			return ret;
+		return mt6375_chg_set_usbsw(ddata, USBSW_USB);
+	}
 	if (en) {
 		/* CDP port specific process */
 		dev_info(ddata->dev, "check CDP block\n");
@@ -1126,15 +1162,17 @@ static int mt6375_chg_enable_bc12(struct mt6375_chg_data *ddata, bool en)
 			msleep(100);
 		}
 		if (i == max_wait_cnt)
-			dev_notice(ddata->dev, "CDP timeout\n", __func__);
+			dev_notice(ddata->dev, "CDP timeout\n");
 		else
-			dev_info(ddata->dev, "CDP free\n", __func__);
+			dev_info(ddata->dev, "CDP free\n");
 	}
-	ret = mt6375_chg_set_usbsw(ddata, en ? USBSW_CHG : USBSW_USB);
+	ret = mt6375_chg_set_usbsw(ddata, USBSW_CHG);
 	if (ret)
 		return ret;
-	return mt6375_chg_field_set(ddata, F_BC12_EN, en);
+	return mt6375_chg_field_set(ddata, F_BC12_EN, 1);
 }
+
+#include "mt6375-tcpm.h"
 
 static void mt6375_rerun_bc12_work(struct work_struct *work)
 {
@@ -1217,6 +1255,9 @@ static void mt6375_chg_bc12_work_func(struct work_struct *work)
 	struct mt6375_chg_platform_data *pdata = dev_get_platdata(ddata->dev);
 	bool attach;
 
+	if (ddata->tcpm_managed)
+		return;
+
 	mutex_lock(&ddata->attach_lock);
 	attach = atomic_read(&ddata->attach);
 	if (pdata->bc12_sel != 0) {
@@ -1264,11 +1305,9 @@ static void mt6375_chg_bc12_work_func(struct work_struct *work)
 			dev_err(ddata->dev, "%s: DCP detected, 5V charging\n", __func__);
 			break;
 		case PORT_STAT_SDP:
-			ddata->psy_desc.type = POWER_SUPPLY_TYPE_USB_DCP;
-			ddata->psy_usb_type = POWER_SUPPLY_USB_TYPE_DCP;
-			bc12_en = true;
-			/* XAGA: treat SDP as a basic 5V charger for now. */
-			dev_err(ddata->dev, "%s: SDP detected, 5V charging\n", __func__);
+			ddata->psy_desc.type = POWER_SUPPLY_TYPE_USB;
+			ddata->psy_usb_type = POWER_SUPPLY_USB_TYPE_SDP;
+			/* Release DP/DM to USB after detecting a data-capable port. */
 			break;
 		case PORT_STAT_CDP:
 			ddata->psy_desc.type = POWER_SUPPLY_TYPE_USB_CDP;
@@ -1334,6 +1373,11 @@ static enum power_supply_property mt6375_chg_psy_properties[] = {
 static int mt6375_chg_property_is_writeable(struct power_supply *psy,
 					    enum power_supply_property psp)
 {
+	struct mt6375_chg_data *ddata = power_supply_get_drvdata(psy);
+
+	/* Managed power requests come from TCPM, not sysfs charging controls. */
+	if (ddata->tcpm_managed)
+		return 0;
 	switch (psp) {
 	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT:
 	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_VOLTAGE:
@@ -1372,8 +1416,8 @@ static int mt6375_chg_get_property(struct power_supply *psy,
 		break;
 	case POWER_SUPPLY_PROP_STATUS:
 		ret = mt6375_chg_field_get(ddata, F_IC_STAT, &_val);
-		if (ddata->chgdev != NULL)
-			ret = mt6375_get_vbus(ddata->chgdev, &vbus);
+		if (!ret)
+			ret = mt6375_chg_iio_read(ddata, ADC_CHAN_CHGVINDIV5, &vbus);
 		if (ret < 0)
 			break;
 		vbus = vbus / 1000;
@@ -1383,12 +1427,10 @@ static int mt6375_chg_get_property(struct power_supply *psy,
 		val->intval = to_psy_status(_val);
 		break;
 	case POWER_SUPPLY_PROP_VOLTAGE_NOW:
-		ret = mt6375_get_adc(ddata->chgdev, ADC_CHANNEL_VBAT,
-				     &val->intval, &val->intval);
+		ret = mt6375_chg_iio_read(ddata, ADC_CHAN_VBAT, &val->intval);
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_NOW:
-		ret = mt6375_get_adc(ddata->chgdev, ADC_CHANNEL_IBAT,
-				     &val->intval, &val->intval);
+		ret = mt6375_chg_iio_read(ddata, ADC_CHAN_IBAT, &val->intval);
 		break;
 	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT:
 		mutex_lock(&ddata->pe_lock);
@@ -1404,6 +1446,8 @@ static int mt6375_chg_get_property(struct power_supply *psy,
 		mutex_lock(&ddata->pe_lock);
 		ret = mt6375_chg_field_get(ddata, F_IAICR, &val->intval);
 		mutex_unlock(&ddata->pe_lock);
+		if (!ret && ddata->tcpm_managed)
+			val->intval *= 1000;
 		break;
 	case POWER_SUPPLY_PROP_INPUT_VOLTAGE_LIMIT:
 		mutex_lock(&ddata->pe_lock);
@@ -1419,11 +1463,13 @@ static int mt6375_chg_get_property(struct power_supply *psy,
 		mutex_unlock(&ddata->attach_lock);
 		break;
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
-		if (ddata->psy_desc.type == POWER_SUPPLY_TYPE_USB)
+		if (ddata->tcpm_managed)
+			val->intval = READ_ONCE(ddata->sink_limit_ua);
+		else if (ddata->psy_desc.type == POWER_SUPPLY_TYPE_USB)
 			val->intval = 500000;
 		break;
 	case POWER_SUPPLY_PROP_VOLTAGE_MAX:
-		if (ddata->psy_desc.type == POWER_SUPPLY_TYPE_USB)
+		if (ddata->tcpm_managed || ddata->psy_desc.type == POWER_SUPPLY_TYPE_USB)
 			val->intval = 5000000;
 		break;
 	case POWER_SUPPLY_PROP_TYPE:
@@ -1471,6 +1517,9 @@ static int mt6375_chg_set_property(struct power_supply *psy,
 	int ret = 0;
 	u32 vbus = 0;
 	struct mt6375_chg_data *ddata = power_supply_get_drvdata(psy);
+
+	if (ddata->tcpm_managed)
+		return mt6375_tcpm_set_property(ddata, psp, val);
 
 	mt_dbg(ddata->dev, "psp=%d\n", psp);
 	switch (psp) {
@@ -2515,6 +2564,15 @@ static const struct charger_ops mt6375_chg_ops = {
 	.set_dpdm_voltage = mi_mt6375_set_dpdm_voltage,
 };
 
+/* No parallel vendor policy may bypass the TCPM power interlock. */
+static const struct charger_ops mt6375_tcpm_chg_ops = {
+	.get_adc = mt6375_get_adc,
+	.get_vbus_adc = mt6375_get_vbus,
+	.get_ibus_adc = mt6375_get_ibus,
+	.get_ibat_adc = mt6375_get_ibat,
+	.get_charge_ic_stat = mt6375_get_charge_ic_stat,
+};
+
 static irqreturn_t mt6375_fl_wdt_handler(int irq, void *data)
 {
 	int ret;
@@ -2540,6 +2598,9 @@ static irqreturn_t mt6375_fl_detach_handler(int irq, void *data)
 struct mt6375_chg_data *ddata = data;
 u32 vbus = 0;
 int ret;
+
+if (ddata->tcpm_managed)
+	return IRQ_HANDLED;
 
 dev_err(ddata->dev, "[MT6375_CHG] %s\n", __func__);
 
@@ -2584,6 +2645,9 @@ static irqreturn_t mt6375_fl_chg_tout_handler(int irq, void *data)
 static irqreturn_t mt6375_fl_bc12_dn_handler(int irq, void *data)
 {
 	struct mt6375_chg_data *ddata = data;
+
+	if (ddata->tcpm_managed)
+		return IRQ_HANDLED;
 
 	dev_err(ddata->dev, "[MT6375_CHG] %s\n", __func__);
 	mutex_lock(&ddata->attach_lock);
@@ -2855,6 +2919,11 @@ static int mt6375_chg_init_psy(struct mt6375_chg_data *ddata)
 
 	mt_dbg(ddata->dev, "%s\n", __func__);
 	memcpy(&ddata->psy_desc, &mt6375_psy_desc, sizeof(ddata->psy_desc));
+	if (ddata->tcpm_managed) {
+		ddata->psy_desc.type = POWER_SUPPLY_TYPE_USB_TYPE_C;
+		ddata->psy_desc.usb_types = BIT(POWER_SUPPLY_USB_TYPE_C);
+		ddata->psy_usb_type = POWER_SUPPLY_USB_TYPE_C;
+	}
 	ddata->psy_desc.name = "mtk-master-charger";
 	ddata->psy = devm_power_supply_register(ddata->dev, &ddata->psy_desc,
 						&cfg);
@@ -2882,7 +2951,8 @@ static int mt6375_chg_init_chgdev(struct mt6375_chg_data *ddata)
 
 	mt_dbg(ddata->dev, "%s\n", __func__);
 	ddata->chgdev = charger_device_register(pdata->chg_name, ddata->dev,
-						ddata, &mt6375_chg_ops,
+						ddata, ddata->tcpm_managed ?
+						&mt6375_tcpm_chg_ops : &mt6375_chg_ops,
 						&mt6375_chg_props);
 	return IS_ERR(ddata->chgdev) ? PTR_ERR(ddata->chgdev) : 0;
 }
@@ -3030,6 +3100,9 @@ static int mt6375_chg_probe(struct platform_device *pdev)
 	}
 
 	ddata->dev = dev;
+	ddata->tcpm_managed = device_property_read_bool(dev, "mediatek,tcpm-managed");
+	ddata->sink_limit_ua = 100000;
+	mutex_init(&ddata->power_lock);
 	init_completion(&ddata->pe_done);
 	init_completion(&ddata->aicc_done);
 	mutex_init(&ddata->attach_lock);
@@ -3071,6 +3144,30 @@ static int mt6375_chg_probe(struct platform_device *pdev)
 		dev_err(dev, "failed to get iio adc\n");
 		goto out_attr;
 	}
+	if (ddata->tcpm_managed) {
+		unsigned int state;
+
+		if (!ddata->iio_adcs) {
+			ret = -EPROBE_DEFER;
+			goto out_attr;
+		}
+		/* Quiesce the bootloader power state before publishing suppliers. */
+		ret = mt6375_tcpm_quiesce(ddata);
+		if (ret)
+			goto out_attr;
+		ret = regmap_update_bits(ddata->rmap, MT6375_REG_CHG_TOP1,
+					 MT6375_MSK_OTG_EN, 0);
+		if (ret)
+			goto out_attr;
+		ret = regmap_read(ddata->rmap, MT6375_REG_CHG_TOP1, &state);
+		if (!ret && (state & MT6375_MSK_OTG_EN))
+			ret = -EIO;
+		if (ret)
+			goto out_attr;
+		ret = mt6375_set_boost_param(ddata, false);
+		if (ret)
+			goto out_attr;
+	}
 
 	ret = mt6375_chg_init_psy(ddata);
 	if (ret < 0) {
@@ -3095,9 +3192,11 @@ static int mt6375_chg_probe(struct platform_device *pdev)
 		dev_err(dev, "failed to init irq\n");
 		goto out_chgdev;
 	}
-	mt6375_chg_pwr_rdy_process(ddata);
-	queue_delayed_work(ddata->wq, &ddata->vbus_check_work,
-			   msecs_to_jiffies(2000));
+	if (!ddata->tcpm_managed) {
+		mt6375_chg_pwr_rdy_process(ddata);
+		queue_delayed_work(ddata->wq, &ddata->vbus_check_work,
+				   msecs_to_jiffies(2000));
+	}
 
 	mt_dbg(dev, "successfully\n");
 	return 0;
@@ -3106,8 +3205,10 @@ out_chgdev:
 out_attr:
 	device_remove_file(ddata->dev, &dev_attr_shipping_mode);
 out_wq:
+	unregister_reboot_notifier(&ddata->reboot_notifier);
 	destroy_workqueue(ddata->wq);
 out:
+	mutex_destroy(&ddata->power_lock);
 	mutex_destroy(&ddata->hm_lock);
 	mutex_destroy(&ddata->cv_lock);
 	mutex_destroy(&ddata->pe_lock);
@@ -3127,6 +3228,7 @@ static void mt6375_chg_remove(struct platform_device *pdev)
 		cancel_delayed_work_sync(&ddata->vbus_check_work);
 		destroy_workqueue(ddata->wq);
 		mutex_destroy(&ddata->hm_lock);
+		mutex_destroy(&ddata->power_lock);
 		mutex_destroy(&ddata->cv_lock);
 		mutex_destroy(&ddata->pe_lock);
 		mutex_destroy(&ddata->attach_lock);

--- a/drivers/power/supply/mediatek/mt6375-tcpm.h
+++ b/drivers/power/supply/mediatek/mt6375-tcpm.h
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/* Included by mt6375-charger.c after the field and USB switch helpers. */
+
+/* power_lock must be held across each sink/source transition. */
+static int mt6375_tcpm_quiesce(struct mt6375_chg_data *ddata)
+{
+	static const enum mt6375_chg_reg_field off[] = {
+		F_CHG_EN, F_BUCK_EN, F_BC12_EN, F_DP_LDO_EN, F_DM_LDO_EN,
+		F_DP_PULL_REN, F_DM_PULL_REN, F_DP_PULL_IEN, F_DM_PULL_IEN,
+		F_DP_DET_EN, F_DM_DET_EN, F_DPDM_SW_VCP_EN, F_MANUAL_MODE,
+		F_BLEED_DIS_EN,
+	};
+	int i, ret;
+
+	for (i = 0; i < ARRAY_SIZE(off); i++) {
+		ret = mt6375_chg_field_set(ddata, off[i], 0);
+		if (ret)
+			return ret;
+	}
+	ret = mt6375_chg_set_usbsw(ddata, USBSW_USB);
+	if (!ret)
+		atomic_set(&ddata->attach, 0);
+	return ret;
+}
+
+static int mt6375_tcpm_source_enable(struct regulator_dev *rdev)
+{
+	struct mt6375_chg_data *ddata = rdev->reg_data;
+	int ret, cleanup, vbus;
+
+	mutex_lock(&ddata->power_lock);
+	if (ddata->power_fault) {
+		ret = -EIO;
+		goto out;
+	}
+	if (ddata->sink_requested) {
+		ret = -EBUSY;
+		goto out;
+	}
+	if (ddata->source_enabled) {
+		ret = 0;
+		goto out;
+	}
+	ret = mt6375_tcpm_quiesce(ddata);
+	if (ret)
+		goto fault;
+
+	/* Fresh ADC conversion: do not boost into an externally powered bus. */
+	ret = mt6375_chg_iio_read(ddata, ADC_CHAN_CHGVINDIV5, &vbus);
+	if (ret)
+		goto out;
+	if (vbus < 0 || vbus >= 800000) {
+		ret = -EBUSY;
+		goto out;
+	}
+	ret = regulator_is_enabled_regmap(rdev);
+	if (ret) {
+		if (ret > 0)
+			ret = -EBUSY;
+		goto fault;
+	}
+	ret = mt6375_set_boost_param(ddata, true);
+	if (ret)
+		goto fault;
+	ret = regulator_enable_regmap(rdev);
+	if (!ret) {
+		ret = regulator_is_enabled_regmap(rdev);
+		if (ret == 1) {
+			ddata->source_enabled = true;
+			ret = 0;
+			goto out;
+		}
+		if (!ret)
+			ret = -EIO;
+	}
+	/* An I2C error may follow a completed write: explicitly try to turn off. */
+	cleanup = regulator_disable_regmap(rdev);
+	if (!cleanup)
+		cleanup = regulator_is_enabled_regmap(rdev);
+	ddata->source_enabled = cleanup != 0;
+	if (!cleanup)
+		mt6375_set_boost_param(ddata, false);
+fault:
+	/* No automatic re-enable after a partially completed power transition. */
+	ddata->power_fault = true;
+out:
+	mutex_unlock(&ddata->power_lock);
+	return ret;
+}
+
+static int mt6375_tcpm_source_disable(struct regulator_dev *rdev)
+{
+	struct mt6375_chg_data *ddata = rdev->reg_data;
+	int ret;
+
+	mutex_lock(&ddata->power_lock);
+	/* Stop boost before restoring buck parameters; never re-enable on error. */
+	ret = regulator_disable_regmap(rdev);
+	if (ret)
+		goto fault;
+	ret = regulator_is_enabled_regmap(rdev);
+	if (ret) {
+		if (ret > 0)
+			ret = -EIO;
+		goto fault;
+	}
+	ddata->source_enabled = false;
+	ret = mt6375_set_boost_param(ddata, false);
+	if (ret)
+		goto fault;
+	goto out;
+fault:
+	ddata->power_fault = true;
+out:
+	mutex_unlock(&ddata->power_lock);
+	return ret;
+}
+
+static int mt6375_tcpm_stop_sink(struct mt6375_chg_data *ddata)
+{
+	int ret, buck_ret;
+
+	/* Attempt both switches even if the first write fails. */
+	ret = mt6375_chg_field_set(ddata, F_CHG_EN, 0);
+	buck_ret = mt6375_chg_field_set(ddata, F_BUCK_EN, 0);
+	if (!ret)
+		ret = buck_ret;
+	if (ret)
+		ddata->power_fault = true;
+	else
+		atomic_set(&ddata->attach, 0);
+	return ret;
+}
+
+static int mt6375_tcpm_apply_sink(struct mt6375_chg_data *ddata)
+{
+	int ret;
+	bool enable = ddata->sink_requested && ddata->sink_limit_ua >= 100000;
+
+	if (!enable)
+		return mt6375_tcpm_stop_sink(ddata);
+	if (ddata->power_fault || ddata->source_enabled)
+		return -EBUSY;
+	ret = regulator_is_enabled_regmap(ddata->rdev);
+	if (ret) {
+		if (ret > 0)
+			ret = -EBUSY;
+		goto fault;
+	}
+
+	/* This managed interface uses power_supply's microamp units. */
+	ret = mt6375_chg_field_set(ddata, F_IAICR, ddata->sink_limit_ua / 1000);
+	if (ret)
+		goto fault;
+	ret = mt6375_chg_field_set(ddata, F_BUCK_EN, 1);
+	if (!ret)
+		ret = mt6375_chg_field_set(ddata, F_CHG_EN, 1);
+	if (ret)
+		goto fault;
+	atomic_set(&ddata->attach, 1);
+	return 0;
+fault:
+	/* A failed lower limit must not leave the previous high-current sink on. */
+	mt6375_tcpm_stop_sink(ddata);
+	ddata->power_fault = true;
+	return ret;
+}
+
+static int mt6375_tcpm_set_property(struct mt6375_chg_data *ddata,
+				    enum power_supply_property psp,
+				    const union power_supply_propval *val)
+{
+	int ret;
+
+	mutex_lock(&ddata->power_lock);
+	switch (psp) {
+	case POWER_SUPPLY_PROP_ONLINE:
+		if (val->intval != 0 && val->intval != 1) {
+			ret = -EINVAL;
+			break;
+		}
+		ddata->sink_requested = val->intval;
+		if (!ddata->sink_requested)
+			ddata->sink_limit_ua = 0;
+		ret = mt6375_tcpm_apply_sink(ddata);
+		break;
+	case POWER_SUPPLY_PROP_INPUT_CURRENT_LIMIT:
+		if (val->intval < 0 || val->intval > 1500000) {
+			ret = -EINVAL;
+			break;
+		}
+		ddata->sink_limit_ua = val->intval;
+		ret = mt6375_tcpm_apply_sink(ddata);
+		break;
+	default:
+		/* Legacy direct charging, DP/DM, and fast-charge knobs are excluded. */
+		ret = -EOPNOTSUPP;
+		break;
+	}
+	mutex_unlock(&ddata->power_lock);
+	if (!ret)
+		power_supply_changed(ddata->psy);
+	return ret;
+}

--- a/drivers/usb/mtu3/mtu3.h
+++ b/drivers/usb/mtu3/mtu3.h
@@ -16,6 +16,7 @@
 #include <linux/extcon.h>
 #include <linux/interrupt.h>
 #include <linux/list.h>
+#include <linux/mutex.h>
 #include <linux/of.h>
 #include <linux/phy/phy.h>
 #include <linux/regulator/consumer.h>
@@ -205,6 +206,9 @@ struct mtu3_gpd_ring {
 * @edev: external connector used to detect vbus and iddig changes
 * @id_nb : notifier for iddig(idpin) detection
 * @dr_work : work for drd mode switch, used to avoid sleep in atomic context
+* @role_lock : serialize role work with local unbound-device recovery
+* @recovery_registered : local recovery sysfs group is installed
+* @sw_vbus_detect : external Type-C controller supplies device VBUS validity
 * @desired_role : role desired to switch
 * @default_role : default mode while usb role is USB_ROLE_NONE
 * @role_sw : use USB Role Switch to support dual-role switch, can't use
@@ -219,6 +223,9 @@ struct otg_switch_mtk {
 	struct extcon_dev *edev;
 	struct notifier_block id_nb;
 	struct work_struct dr_work;
+	struct mutex role_lock;
+	bool recovery_registered;
+	bool sw_vbus_detect;
 	enum usb_role desired_role;
 	enum usb_role default_role;
 	struct usb_role_switch *role_sw;

--- a/drivers/usb/mtu3/mtu3_core.c
+++ b/drivers/usb/mtu3/mtu3_core.c
@@ -714,6 +714,9 @@ static irqreturn_t mtu3_link_isr(struct mtu3 *mtu)
 		break;
 	}
 	dev_dbg(mtu->dev, "%s: %s\n", __func__, usb_speed_string(udev_speed));
+	if (of_machine_is_compatible("xiaomi,xaga"))
+		dev_info_ratelimited(mtu->dev, "USB link speed event: %s\n",
+				     usb_speed_string(udev_speed));
 	mtu3_dbg_trace(mtu->dev, "link speed %s",
 		       usb_speed_string(udev_speed));
 
@@ -781,8 +784,11 @@ static irqreturn_t mtu3_u2_common_isr(struct mtu3 *mtu)
 	if (u2comm & RESUME_INTR)
 		mtu3_gadget_resume(mtu);
 
-	if (u2comm & RESET_INTR)
+	if (u2comm & RESET_INTR) {
+		if (of_machine_is_compatible("xiaomi,xaga"))
+			dev_info_ratelimited(mtu->dev, "USB2 reset received\n");
 		mtu3_gadget_reset(mtu);
+	}
 
 	return IRQ_HANDLED;
 }

--- a/drivers/usb/mtu3/mtu3_dr.c
+++ b/drivers/usb/mtu3/mtu3_dr.c
@@ -84,7 +84,7 @@ static void switch_port_to_host(struct ssusb_mtk *ssusb)
 	toggle_opstate(ssusb);
 }
 
-static void switch_port_to_device(struct ssusb_mtk *ssusb)
+static int switch_port_to_device(struct ssusb_mtk *ssusb)
 {
 	u32 check_clk = 0;
 
@@ -97,7 +97,7 @@ static void switch_port_to_device(struct ssusb_mtk *ssusb)
 		check_clk = SSUSB_U3_MAC_RST_B_STS;
 	}
 
-	ssusb_check_clocks(ssusb, check_clk);
+	return ssusb_check_clocks(ssusb, check_clk);
 }
 
 int ssusb_set_vbus(struct otg_switch_mtk *otg_sx, int is_on)
@@ -125,14 +125,42 @@ int ssusb_set_vbus(struct otg_switch_mtk *otg_sx, int is_on)
 	return 0;
 }
 
-static void ssusb_mode_sw_work(struct work_struct *work)
+/*
+ * Xaga routes VBUS detection through its external Type-C controller. Match
+ * the vendor MT6895 device-mode setup: this overrides the MAC's VBUS input,
+ * not the physical VBUS supply. TCPM's DEVICE/NONE events assert/clear it.
+ */
+static void ssusb_set_device_vbus(struct ssusb_mtk *ssusb, bool valid)
+{
+	u32 u2_ctrl, misc;
+
+	if (!ssusb->otg_switch.sw_vbus_detect)
+		return;
+
+	u2_ctrl = mtu3_readl(ssusb->ippc_base, SSUSB_U2_CTRL(0));
+	misc = mtu3_readl(ssusb->mac_base, U3D_MISC_CTRL);
+	if (valid) {
+		u2_ctrl &= ~SSUSB_U2_PORT_OTG_SEL;
+		misc |= VBUS_FRC_EN | VBUS_ON;
+	} else {
+		u2_ctrl |= SSUSB_U2_PORT_OTG_SEL;
+		misc &= ~(VBUS_FRC_EN | VBUS_ON);
+	}
+	mtu3_writel(ssusb->ippc_base, SSUSB_U2_CTRL(0), u2_ctrl);
+	mtu3_writel(ssusb->mac_base, U3D_MISC_CTRL, misc);
+}
+
+static void ssusb_mode_sw_work_locked(struct work_struct *work)
 {
 	struct otg_switch_mtk *otg_sx =
 		container_of(work, struct otg_switch_mtk, dr_work);
 	struct ssusb_mtk *ssusb = otg_sx_to_ssusb(otg_sx);
 	struct mtu3 *mtu = ssusb->u3d;
-	enum usb_role desired_role = otg_sx->desired_role;
+	enum usb_role desired_role = READ_ONCE(otg_sx->desired_role);
+	bool device_attached = desired_role == USB_ROLE_DEVICE;
 	enum usb_role current_role;
+	enum phy_mode phy_mode;
+	int i, ret;
 
 	current_role = ssusb->is_host ? USB_ROLE_HOST : USB_ROLE_DEVICE;
 
@@ -143,12 +171,29 @@ static void ssusb_mode_sw_work(struct work_struct *work)
 			desired_role = USB_ROLE_DEVICE;
 	}
 
-	if (current_role == desired_role)
+	if (current_role == desired_role && !otg_sx->sw_vbus_detect)
 		return;
 
 	dev_dbg(ssusb->dev, "set role : %s\n", usb_role_string(desired_role));
 	mtu3_dbg_trace(ssusb->dev, "set role : %s", usb_role_string(desired_role));
-	pm_runtime_get_sync(ssusb->dev);
+	ret = pm_runtime_resume_and_get(ssusb->dev);
+	if (ret < 0)
+		return;
+
+	/* NONE can map to DEVICE, but must not leave VBUS-valid asserted. */
+	if (!device_attached)
+		ssusb_set_device_vbus(ssusb, false);
+	if (current_role == desired_role)
+		goto update_vbus;
+
+	phy_mode = desired_role == USB_ROLE_HOST ? PHY_MODE_USB_HOST : PHY_MODE_USB_DEVICE;
+	for (i = 0; i < ssusb->num_phys; i++) {
+		ret = phy_set_mode(ssusb->phys[i], phy_mode);
+		if (ret) {
+			dev_err(ssusb->dev, "failed to set PHY role: %d\n", ret);
+			goto out;
+		}
+	}
 
 	switch (desired_role) {
 	case USB_ROLE_HOST:
@@ -162,15 +207,101 @@ static void ssusb_mode_sw_work(struct work_struct *work)
 		ssusb_set_force_mode(ssusb, MTU3_DR_FORCE_DEVICE);
 		ssusb->is_host = false;
 		ssusb_set_vbus(otg_sx, 0);
-		switch_port_to_device(ssusb);
+		ret = switch_port_to_device(ssusb);
+		if (ret)
+			goto out;
 		mtu3_start(mtu);
 		break;
 	case USB_ROLE_NONE:
 	default:
 		dev_err(ssusb->dev, "invalid role\n");
 	}
+update_vbus:
+	ssusb_set_device_vbus(ssusb, device_attached &&
+			      !ssusb->is_host && mtu->is_active);
+out:
 	pm_runtime_put(ssusb->dev);
 }
+
+static void ssusb_mode_sw_work(struct work_struct *work)
+{
+	struct otg_switch_mtk *otg_sx =
+		container_of(work, struct otg_switch_mtk, dr_work);
+
+	mutex_lock(&otg_sx->role_lock);
+	ssusb_mode_sw_work_locked(work);
+	mutex_unlock(&otg_sx->role_lock);
+}
+
+/* Caller holds role_lock and the gadget device lock (excludes bind/unbind). */
+static int ssusb_recover_unbound_device(struct ssusb_mtk *ssusb)
+{
+	struct otg_switch_mtk *otg_sx = &ssusb->otg_switch;
+	struct mtu3 *mtu = ssusb->u3d;
+	unsigned long flags;
+	int i, ret;
+
+	if (ssusb->is_host || READ_ONCE(otg_sx->desired_role) != USB_ROLE_DEVICE)
+		return -EBUSY;
+	if (mtu->gadget_driver || mtu->softconnect || mtu->connected)
+		return -EBUSY;
+
+	/* Never change the power role or call the VBUS regulator here. */
+	for (i = 0; i < ssusb->num_phys; i++) {
+		ret = phy_set_mode(ssusb->phys[i], PHY_MODE_USB_DEVICE);
+		if (ret)
+			return ret;
+	}
+
+	spin_lock_irqsave(&mtu->lock, flags);
+	mtu3_stop(mtu);
+	spin_unlock_irqrestore(&mtu->lock, flags);
+	synchronize_irq(mtu->irq);
+
+	ssusb_set_force_mode(ssusb, MTU3_DR_FORCE_DEVICE);
+	ret = switch_port_to_device(ssusb);
+	if (ret)
+		return ret;
+
+	spin_lock_irqsave(&mtu->lock, flags);
+	mtu3_start(mtu);
+	spin_unlock_irqrestore(&mtu->lock, flags);
+	return 0;
+}
+
+/* Local xaga recovery interface; ordinary repeated role requests stay no-ops. */
+static ssize_t device_recover_store(struct device *dev,
+				   struct device_attribute *attr,
+				   const char *buf, size_t count)
+{
+	struct ssusb_mtk *ssusb = dev_get_drvdata(dev);
+	struct mtu3 *mtu = ssusb->u3d;
+	int ret;
+
+	if (!sysfs_streq(buf, "1"))
+		return -EINVAL;
+	ret = pm_runtime_resume_and_get(dev);
+	if (ret < 0)
+		return ret;
+
+	device_lock(&mtu->g.dev);
+	mutex_lock(&ssusb->otg_switch.role_lock);
+	ret = ssusb_recover_unbound_device(ssusb);
+	mutex_unlock(&ssusb->otg_switch.role_lock);
+	device_unlock(&mtu->g.dev);
+	pm_runtime_put(dev);
+	dev_info(dev, "unbound device recovery result: %d\n", ret);
+	return ret ? ret : count;
+}
+static DEVICE_ATTR_WO(device_recover);
+
+static struct attribute *ssusb_recovery_attrs[] = {
+	&dev_attr_device_recover.attr,
+	NULL,
+};
+static const struct attribute_group ssusb_recovery_group = {
+	.attrs = ssusb_recovery_attrs,
+};
 
 static void ssusb_set_mode(struct otg_switch_mtk *otg_sx, enum usb_role role)
 {
@@ -179,7 +310,7 @@ static void ssusb_set_mode(struct otg_switch_mtk *otg_sx, enum usb_role role)
 	if (ssusb->dr_mode != USB_DR_MODE_OTG)
 		return;
 
-	otg_sx->desired_role = role;
+	WRITE_ONCE(otg_sx->desired_role, role);
 	queue_work(system_freezable_wq, &otg_sx->dr_work);
 }
 
@@ -295,12 +426,14 @@ static int ssusb_role_sw_register(struct otg_switch_mtk *otg_sx)
 	role_sx_desc.get = ssusb_role_sw_get;
 	role_sx_desc.fwnode = dev_fwnode(dev);
 	role_sx_desc.driver_data = ssusb;
-	role_sx_desc.allow_userspace_control = true;
+	/* Only TCPM may assert attachment on boards using software VBUS detect. */
+	role_sx_desc.allow_userspace_control = !otg_sx->sw_vbus_detect;
 	otg_sx->role_sw = usb_role_switch_register(dev, &role_sx_desc);
 	if (IS_ERR(otg_sx->role_sw))
 		return PTR_ERR(otg_sx->role_sw);
 
-	ssusb_set_mode(otg_sx, otg_sx->default_role);
+	ssusb_set_mode(otg_sx, otg_sx->sw_vbus_detect ?
+		       USB_ROLE_NONE : otg_sx->default_role);
 
 	return 0;
 }
@@ -311,6 +444,9 @@ int ssusb_otg_switch_init(struct ssusb_mtk *ssusb)
 	int ret = 0;
 
 	INIT_WORK(&otg_sx->dr_work, ssusb_mode_sw_work);
+	mutex_init(&otg_sx->role_lock);
+	otg_sx->sw_vbus_detect = otg_sx->role_sw_used &&
+		of_machine_is_compatible("xiaomi,xaga");
 
 	if (otg_sx->manual_drd_enabled)
 		ssusb_dr_debugfs_init(ssusb);
@@ -319,6 +455,15 @@ int ssusb_otg_switch_init(struct ssusb_mtk *ssusb)
 	else
 		ret = ssusb_extcon_register(otg_sx);
 
+	if (!ret && otg_sx->role_sw_used && of_machine_is_compatible("xiaomi,xaga")) {
+		ret = device_add_group(ssusb->dev, &ssusb_recovery_group);
+		if (ret) {
+			ssusb_otg_switch_exit(ssusb);
+			return ret;
+		}
+		otg_sx->recovery_registered = true;
+	}
+
 	return ret;
 }
 
@@ -326,6 +471,10 @@ void ssusb_otg_switch_exit(struct ssusb_mtk *ssusb)
 {
 	struct otg_switch_mtk *otg_sx = &ssusb->otg_switch;
 
+	if (otg_sx->recovery_registered) {
+		device_remove_group(ssusb->dev, &ssusb_recovery_group);
+		otg_sx->recovery_registered = false;
+	}
 	cancel_work_sync(&otg_sx->dr_work);
 	usb_role_switch_unregister(otg_sx->role_sw);
 }

--- a/drivers/usb/mtu3/mtu3_plat.c
+++ b/drivers/usb/mtu3/mtu3_plat.c
@@ -287,10 +287,12 @@ static int get_ssusb_rscs(struct platform_device *pdev, struct ssusb_mtk *ssusb)
 	of_property_read_u32(node, "mediatek,u2p-dis-msk",
 			     &ssusb->u2p_dis_msk);
 
-	otg_sx->vbus = devm_regulator_get(dev, "vbus");
+	otg_sx->vbus = devm_regulator_get_optional(dev, "vbus");
 	if (IS_ERR(otg_sx->vbus)) {
-		dev_err(dev, "failed to get vbus\n");
-		return PTR_ERR(otg_sx->vbus);
+		ret = PTR_ERR(otg_sx->vbus);
+		if (ret != -ENODEV)
+			return dev_err_probe(dev, ret, "failed to get vbus\n");
+		otg_sx->vbus = NULL;
 	}
 
 	if (ssusb->dr_mode == USB_DR_MODE_HOST)

--- a/drivers/usb/typec/tcpm/tcpci.c
+++ b/drivers/usb/typec/tcpm/tcpci.c
@@ -304,9 +304,10 @@ static int tcpci_set_polarity(struct tcpc_dev *tcpc,
 	if (ret < 0)
 		return ret;
 
-	return regmap_write(tcpci->regmap, TCPC_TCPC_CTRL,
-			   (polarity == TYPEC_POLARITY_CC2) ?
-			   TCPC_TCPC_CTRL_ORIENTATION : 0);
+	return regmap_update_bits(tcpci->regmap, TCPC_TCPC_CTRL,
+				  TCPC_TCPC_CTRL_ORIENTATION,
+				  (polarity == TYPEC_POLARITY_CC2) ?
+				  TCPC_TCPC_CTRL_ORIENTATION : 0);
 }
 
 static int tcpci_set_orientation(struct tcpc_dev *tcpc,
@@ -521,6 +522,20 @@ static bool tcpci_is_vbus_vsafe0v(struct tcpc_dev *tcpc)
 	return !!(reg & TCPC_EXTENDED_STATUS_VSAFE0V);
 }
 
+static int tcpci_get_current_limit(struct tcpc_dev *tcpc)
+{
+	struct tcpci *tcpci = tcpc_to_tcpci(tcpc);
+
+	return tcpci->data->get_current_limit(tcpci, tcpci->data);
+}
+
+static int tcpci_set_current_limit(struct tcpc_dev *tcpc, u32 max_ma, u32 mv)
+{
+	struct tcpci *tcpci = tcpc_to_tcpci(tcpc);
+
+	return tcpci->data->set_current_limit(tcpci, tcpci->data, max_ma, mv);
+}
+
 static int tcpci_set_vbus(struct tcpc_dev *tcpc, bool source, bool sink)
 {
 	struct tcpci *tcpci = tcpc_to_tcpci(tcpc);
@@ -712,17 +727,54 @@ static int tcpci_init(struct tcpc_dev *tcpc)
 	return 0;
 }
 
+/* Leave RX_STATUS pending on I/O errors so an unread packet is not lost. */
+static int tcpci_read_message(struct tcpci *tcpci, struct pd_message *msg)
+{
+	unsigned int cnt, payload_cnt;
+	u16 header;
+	int ret;
+
+	ret = regmap_read(tcpci->regmap, TCPC_RX_BYTE_CNT, &cnt);
+	if (ret)
+		return ret;
+
+	/* Byte count includes the frame type and two-byte PD header. */
+	if (cnt < 3 || cnt > 3 + sizeof(msg->payload))
+		return -EPROTO;
+	payload_cnt = cnt - 3;
+
+	ret = tcpci_read16(tcpci, TCPC_RX_HDR, &header);
+	if (ret)
+		return ret;
+	if (payload_cnt != pd_header_cnt(header) * sizeof(msg->payload[0]))
+		return -EPROTO;
+	msg->header = cpu_to_le16(header);
+
+	if (payload_cnt) {
+		ret = regmap_raw_read(tcpci->regmap, TCPC_RX_DATA,
+				      msg->payload, payload_cnt);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 irqreturn_t tcpci_irq(struct tcpci *tcpci)
 {
 	u16 status;
 	int ret;
 	int irq_ret;
+	int rx_ret;
 	unsigned int raw;
 
-	tcpci_read16(tcpci, TCPC_ALERT, &status);
+	ret = tcpci_read16(tcpci, TCPC_ALERT, &status);
+	if (ret)
+		return IRQ_NONE;
 	irq_ret = status & tcpci->alert_mask;
 
 process_status:
+	rx_ret = 0;
 	/*
 	 * Clear alert status for everything except RX_STATUS, which shouldn't
 	 * be cleared until we have successfully retrieved message.
@@ -747,36 +799,19 @@ process_status:
 	}
 
 	if (status & TCPC_ALERT_RX_STATUS) {
-		struct pd_message msg;
-		unsigned int cnt, payload_cnt;
-		u16 header;
+		struct pd_message msg = {};
 
-		regmap_read(tcpci->regmap, TCPC_RX_BYTE_CNT, &cnt);
-		/*
-		 * 'cnt' corresponds to READABLE_BYTE_COUNT in section 4.4.14
-		 * of the TCPCI spec [Rev 2.0 Ver 1.0 October 2017] and is
-		 * defined in table 4-36 as one greater than the number of
-		 * bytes received. And that number includes the header. So:
-		 */
-		if (cnt > 3)
-			payload_cnt = cnt - (1 + sizeof(msg.header));
+		rx_ret = tcpci_read_message(tcpci, &msg);
+		if (!rx_ret || rx_ret == -EPROTO) {
+			/* Consume valid packets and discard malformed ones. */
+			ret = tcpci_write16(tcpci, TCPC_ALERT, TCPC_ALERT_RX_STATUS);
+			if (ret)
+				rx_ret = ret;
+		}
+		if (rx_ret)
+			dev_err_ratelimited(tcpci->dev, "PD receive failed: %d\n", rx_ret);
 		else
-			payload_cnt = 0;
-
-		tcpci_read16(tcpci, TCPC_RX_HDR, &header);
-		msg.header = cpu_to_le16(header);
-
-		if (WARN_ON(payload_cnt > sizeof(msg.payload)))
-			payload_cnt = sizeof(msg.payload);
-
-		if (payload_cnt > 0)
-			regmap_raw_read(tcpci->regmap, TCPC_RX_DATA,
-					&msg.payload, payload_cnt);
-
-		/* Read complete, clear RX status alert bit */
-		tcpci_write16(tcpci, TCPC_ALERT, TCPC_ALERT_RX_STATUS);
-
-		tcpm_pd_receive(tcpci->port, &msg, TCPC_TX_SOP);
+			tcpm_pd_receive(tcpci->port, &msg, TCPC_TX_SOP);
 	}
 
 	if (tcpci->data->vbus_vsafe0v && (status & TCPC_ALERT_EXTENDED_STATUS)) {
@@ -795,7 +830,13 @@ process_status:
 	else if (status & TCPC_ALERT_TX_FAILED)
 		tcpm_pd_transmit_complete(tcpci->port, TCPC_TX_FAILED);
 
-	tcpci_read16(tcpci, TCPC_ALERT, &status);
+	/* Finish other events, but do not spin on an unread RX packet. */
+	if (rx_ret)
+		return IRQ_RETVAL(irq_ret);
+
+	ret = tcpci_read16(tcpci, TCPC_ALERT, &status);
+	if (ret)
+		return IRQ_RETVAL(irq_ret);
 
 	if (status & tcpci->alert_mask)
 		goto process_status;
@@ -848,6 +889,10 @@ struct tcpci *tcpci_register_port(struct device *dev, struct tcpci_data *data)
 	tcpci->tcpc.init = tcpci_init;
 	tcpci->tcpc.get_vbus = tcpci_get_vbus;
 	tcpci->tcpc.set_vbus = tcpci_set_vbus;
+	if (data->get_current_limit)
+		tcpci->tcpc.get_current_limit = tcpci_get_current_limit;
+	if (data->set_current_limit)
+		tcpci->tcpc.set_current_limit = tcpci_set_current_limit;
 	tcpci->tcpc.set_cc = tcpci_set_cc;
 	tcpci->tcpc.apply_rc = tcpci_apply_rc;
 	tcpci->tcpc.get_cc = tcpci_get_cc;

--- a/drivers/usb/typec/tcpm/tcpci_mt6375.c
+++ b/drivers/usb/typec/tcpm/tcpci_mt6375.c
@@ -16,6 +16,8 @@
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/pm_wakeirq.h>
+#include <linux/power_supply.h>
+#include <linux/property.h>
 #include <linux/regmap.h>
 #include <linux/regulator/consumer.h>
 #include <linux/usb/tcpci.h>
@@ -46,10 +48,13 @@
 #define MT6375_NORMAL_RP_DUTY 330
 
 struct mt6375_priv {
-    struct device *dev;
-    struct regulator *vbus;
-    struct tcpci *tcpci;
-    struct tcpci_data tcpci_data;
+	struct device *dev;
+	struct regulator *vbus;
+	struct power_supply *charger;
+	bool vbus_on;
+	bool power_fault;
+	struct tcpci *tcpci;
+	struct tcpci_data tcpci_data;
 };
 
 static int mt6375_write16(struct regmap *regmap, unsigned int reg, u16 val)
@@ -159,27 +164,133 @@ static int mt6375_start_drp_toggling(struct tcpci *tcpci,
     return regmap_write(data->regmap, MT6375_REG_LPWRCTRL3, 0xD8);
 }
 
-static int mt6375_set_vbus(struct tcpci *tcpci, struct tcpci_data *data,
-                           bool source, bool sink)
+static int mt6375_get_current_limit(struct tcpci *tcpci, struct tcpci_data *data)
 {
-    struct mt6375_priv *priv = container_of(data, struct mt6375_priv,
-                                            tcpci_data);
-    int ret;
+	/* Default Rp gives no PD/Type-C higher-current entitlement. */
+	return 100;
+}
 
-    if (!priv->vbus)
-        return 0;
+static int mt6375_set_current_limit(struct tcpci *tcpci, struct tcpci_data *data,
+				    u32 max_ma, u32 mv)
+{
+	struct mt6375_priv *priv = container_of(data, struct mt6375_priv, tcpci_data);
+	union power_supply_propval value;
 
-    ret = regulator_is_enabled(priv->vbus);
-    if (ret < 0)
-        return ret;
+	/* Fixed 5 V only. Default USB current stays at 100 mA before enumeration. */
+	if (mv && mv != 5000)
+		return -EINVAL;
+	if (!mv || max_ma < 100)
+		value.intval = 0;
+	else if (max_ma <= 500)
+		value.intval = 100000;
+	else
+		value.intval = min(max_ma, 1500U) * 1000;
+	return power_supply_set_property(priv->charger,
+					POWER_SUPPLY_PROP_INPUT_CURRENT_LIMIT, &value);
+}
 
-    if (ret && !source)
-        return regulator_disable(priv->vbus);
+/* TCPM serializes callbacks. Only this consumer owns the boost enable vote. */
+static int mt6375_set_managed_vbus(struct mt6375_priv *priv, bool source, bool sink)
+{
+	struct regmap *map = priv->tcpci_data.regmap;
+	union power_supply_propval value = { .intval = 0 };
+	unsigned int status;
+	int ret, cleanup;
 
-    if (!ret && source)
-        return regulator_enable(priv->vbus);
+	if (source && sink)
+		return -EINVAL;
+	if (priv->power_fault && (source || sink))
+		return -EIO;
 
-    return 0;
+	if (!source && priv->vbus_on) {
+		ret = regulator_disable(priv->vbus);
+		if (ret)
+			goto fault;
+		priv->vbus_on = false;
+	}
+	if (!source) {
+		ret = regmap_write(map, TCPC_COMMAND, TCPC_CMD_DISABLE_SRC_VBUS);
+		if (ret)
+			goto fault;
+	}
+	if (!sink) {
+		ret = regmap_write(map, TCPC_COMMAND, TCPC_CMD_DISABLE_SINK_VBUS);
+		if (ret)
+			goto fault;
+		ret = power_supply_set_property(priv->charger, POWER_SUPPLY_PROP_ONLINE, &value);
+		if (ret)
+			goto fault;
+	}
+	if (source && !priv->vbus_on) {
+		/* Independent of the PMIC ADC check; propagate failed status reads. */
+		ret = regmap_read(map, TCPC_POWER_STATUS, &status);
+		if (ret)
+			return ret;
+		if (status & TCPC_POWER_STATUS_VBUS_PRES)
+			return -EBUSY;
+		ret = regulator_enable(priv->vbus);
+		if (ret)
+			return ret;
+		priv->vbus_on = true;
+		ret = regmap_write(map, TCPC_COMMAND, TCPC_CMD_SRC_VBUS_DEFAULT);
+		if (ret) {
+			cleanup = regulator_disable(priv->vbus);
+			if (!cleanup)
+				priv->vbus_on = false;
+			goto fault;
+		}
+	}
+	if (sink) {
+		ret = regulator_is_enabled(priv->vbus);
+		if (ret) {
+			if (ret > 0)
+				ret = -EBUSY;
+			goto fault;
+		}
+		ret = regmap_write(map, TCPC_COMMAND, TCPC_CMD_SINK_VBUS);
+		if (ret)
+			goto fault;
+		value.intval = 1;
+		ret = power_supply_set_property(priv->charger, POWER_SUPPLY_PROP_ONLINE, &value);
+		if (ret) {
+			regmap_write(map, TCPC_COMMAND, TCPC_CMD_DISABLE_SINK_VBUS);
+			value.intval = 0;
+			power_supply_set_property(priv->charger, POWER_SUPPLY_PROP_ONLINE, &value);
+			goto fault;
+		}
+	}
+	/* Entire command sequence handled here; bypass the generic TCPCI writes. */
+	return 1;
+fault:
+	priv->power_fault = true;
+	dev_err(priv->dev, "VBUS transition failed: %d; further power-on blocked\n", ret);
+	return ret;
+}
+
+static int mt6375_set_vbus(struct tcpci *tcpci, struct tcpci_data *data,
+			   bool source, bool sink)
+{
+	struct mt6375_priv *priv = container_of(data, struct mt6375_priv,
+					    tcpci_data);
+	int ret;
+
+	if (priv->charger)
+		return mt6375_set_managed_vbus(priv, source, sink);
+
+	if (!priv->vbus)
+		return 0;
+
+	ret = regulator_is_enabled(priv->vbus);
+	if (ret < 0)
+		return ret;
+
+	if (ret && !source)
+		return regulator_disable(priv->vbus);
+
+	if (!ret && source)
+		return regulator_enable(priv->vbus);
+
+	return 0;
 }
 
 static irqreturn_t mt6375_irq_handler(int irq, void *dev_id)
@@ -196,51 +307,68 @@ static void mt6375_unregister_tcpci_port(void *tcpci)
 
 static int mt6375_tcpc_probe(struct platform_device *pdev)
 {
-    struct mt6375_priv *priv;
-    struct device *dev = &pdev->dev;
-    int irq, ret;
+	struct mt6375_priv *priv;
+	struct device *dev = &pdev->dev;
+	int irq, ret;
 
-    priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
-    if (!priv)
-        return -ENOMEM;
+	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
 
-    priv->dev = dev;
+	priv->dev = dev;
 
-    priv->tcpci_data.regmap = dev_get_regmap(dev->parent, NULL);
-    if (!priv->tcpci_data.regmap)
-        return dev_err_probe(dev, -ENODEV, "Failed to get parent regmap\n");
+	priv->tcpci_data.regmap = dev_get_regmap(dev->parent, NULL);
+	if (!priv->tcpci_data.regmap)
+		return dev_err_probe(dev, -ENODEV, "Failed to get parent regmap\n");
 
-    irq = platform_get_irq_byname(pdev, "PD_IRQB");
-    if (irq < 0)
-        return irq;
+	irq = platform_get_irq_byname(pdev, "PD_IRQB");
+	if (irq < 0)
+		return irq;
 
-    priv->tcpci_data.auto_discharge_disconnect = 1;
-    priv->tcpci_data.init = mt6375_tcpc_init;
-    priv->tcpci_data.start_drp_toggling = mt6375_start_drp_toggling;
+	priv->tcpci_data.auto_discharge_disconnect = 1;
+	priv->tcpci_data.init = mt6375_tcpc_init;
+	priv->tcpci_data.start_drp_toggling = mt6375_start_drp_toggling;
 
-    priv->vbus = devm_regulator_get_optional(dev, "vbus");
-    if (!IS_ERR(priv->vbus))
-        priv->tcpci_data.set_vbus = mt6375_set_vbus;
+	priv->vbus = devm_regulator_get_optional(dev, "vbus");
+	if (IS_ERR(priv->vbus)) {
+		ret = PTR_ERR(priv->vbus);
+		if (ret != -ENODEV)
+			return dev_err_probe(dev, ret, "Failed to get VBUS regulator\n");
+		priv->vbus = NULL;
+	}
+	if (device_property_present(dev, "power-supplies")) {
+		if (!priv->vbus)
+			return dev_err_probe(dev, -EINVAL, "Managed port needs VBUS regulator\n");
+		priv->charger = devm_power_supply_get_by_reference(dev, "power-supplies");
+		if (IS_ERR(priv->charger))
+			return dev_err_probe(dev, PTR_ERR(priv->charger), "Charger unavailable\n");
+		if (!priv->charger)
+			return -EPROBE_DEFER;
+		priv->tcpci_data.set_current_limit = mt6375_set_current_limit;
+		priv->tcpci_data.get_current_limit = mt6375_get_current_limit;
+	}
+	if (priv->vbus)
+		priv->tcpci_data.set_vbus = mt6375_set_vbus;
 
-    priv->tcpci = tcpci_register_port(dev, &priv->tcpci_data);
-    if (IS_ERR(priv->tcpci))
-        return dev_err_probe(dev, PTR_ERR(priv->tcpci),
-                             "Failed to register tcpci port\n");
+	priv->tcpci = tcpci_register_port(dev, &priv->tcpci_data);
+	if (IS_ERR(priv->tcpci))
+		return dev_err_probe(dev, PTR_ERR(priv->tcpci),
+				     "Failed to register tcpci port\n");
 
-    ret = devm_add_action_or_reset(dev, mt6375_unregister_tcpci_port,
-                                   priv->tcpci);
-    if (ret)
-        return ret;
+	ret = devm_add_action_or_reset(dev, mt6375_unregister_tcpci_port,
+				       priv->tcpci);
+	if (ret)
+		return ret;
 
-    ret = devm_request_threaded_irq(dev, irq, NULL, mt6375_irq_handler,
-                                    IRQF_ONESHOT, dev_name(dev), priv);
-    if (ret)
-        return dev_err_probe(dev, ret, "Failed to request irq\n");
+	ret = devm_request_threaded_irq(dev, irq, NULL, mt6375_irq_handler,
+					IRQF_ONESHOT, dev_name(dev), priv);
+	if (ret)
+		return dev_err_probe(dev, ret, "Failed to request irq\n");
 
-    device_init_wakeup(dev, true);
-    dev_pm_set_wake_irq(dev, irq);
+	device_init_wakeup(dev, true);
+	dev_pm_set_wake_irq(dev, irq);
 
-    return 0;
+	return 0;
 }
 
 static void mt6375_tcpc_remove(struct platform_device *pdev)

--- a/include/linux/phy/phy-mtk-usb.h
+++ b/include/linux/phy/phy-mtk-usb.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __PHY_MTK_USB_H
+#define __PHY_MTK_USB_H
+
+/* MediaTek charger DP/DM switch commands for PHY_MODE_USB_DEVICE. */
+#define MTK_PHY_MODE_BC11_SET	1
+#define MTK_PHY_MODE_BC11_CLR	2
+
+#endif /* __PHY_MTK_USB_H */

--- a/include/linux/usb/tcpci.h
+++ b/include/linux/usb/tcpci.h
@@ -222,6 +222,10 @@ struct tcpci_data {
 	int (*start_drp_toggling)(struct tcpci *tcpci, struct tcpci_data *data,
 				  enum typec_cc_status cc);
 	int (*set_vbus)(struct tcpci *tcpci, struct tcpci_data *data, bool source, bool sink);
+	/* Optional sink limit, in mA/mV, from the negotiated TCPM contract. */
+	int (*get_current_limit)(struct tcpci *tcpci, struct tcpci_data *data);
+	int (*set_current_limit)(struct tcpci *tcpci, struct tcpci_data *data,
+				 u32 max_ma, u32 mv);
 	void (*frs_sourcing_vbus)(struct tcpci *tcpci, struct tcpci_data *data);
 	void (*set_partner_usb_comm_capable)(struct tcpci *tcpci, struct tcpci_data *data,
 					     bool capable);


### PR DESCRIPTION
This series brings up USB peripheral mode and guarded OTG host support on Xiaomi Redmi Note 11T Pro / POCO X4 GT (xaga, MT6895).

It includes:
- MTU3 dual-role and peripheral VBUS synchronization with TCPM
- Type-C PD and TCPCI message handling fixes
- MT6375 BC1.2 handoff and guarded OTG VBUS sourcing
- xaga Type-C/TCPM device-tree support

Tested on xaga hardware.
